### PR TITLE
DataSource.getIDs handles numeric IDs

### DIFF
--- a/models/DataSource.js
+++ b/models/DataSource.js
@@ -206,7 +206,11 @@ var DataSource = exports = Class(BasicDataSource, function(supr) {
 		return this;
 	};
 
-	this.getIDs = function () { return Object.keys(this._byID); };
+	this.getIDs = function () {
+		return this._byIndex.map(function (item) {
+			return item[this.key];
+		}, this);
+	};
 
 	this.contains = function(id) {
 		return !!this._byID[id];


### PR DESCRIPTION
Object.keys will return strings whether or not the keys themselves are
strings. By mapping over the backing array, we can pluck each of the IDs
and maintain their type.
